### PR TITLE
Adding setup script

### DIFF
--- a/djangoUnescoProject/setup.py
+++ b/djangoUnescoProject/setup.py
@@ -1,0 +1,33 @@
+from setuptools import setup, find_packages
+
+import komidl.constants as constants
+
+setup(
+    # Application name:
+    name="UNESCO DB",
+    # Version number
+    version="0.0.1",
+    description="A database for UNESCO Indigenous education researchers.",
+    # Packages
+    packages=find_packages(),
+
+    # Application author details:
+    author="Andrew Ferreira, Asma Hassan, Dan Sheng, Eric Dao, Shahriar Dhrubo",
+    author_email="acferreir4@gmail.com",
+    url="https://github.com/acferreir4/UNESCO-Database-Project",
+
+    # Include additional files into the package
+    include_package_data=True,
+
+    license="LICENSE",
+    long_description=open("README.md").read(),
+
+    # Dependent packages (distributions)
+    install_requires=[
+        "django",
+        "django-crispy-forms",
+		"channels_redis",
+		"channels",
+		"pillow",
+    ],
+)

--- a/djangoUnescoProject/setup.py
+++ b/djangoUnescoProject/setup.py
@@ -1,7 +1,5 @@
 from setuptools import setup, find_packages
 
-import komidl.constants as constants
-
 setup(
     # Application name:
     name="UNESCO DB",


### PR DESCRIPTION
This script will help developers/users install all the needed dependencies for the project.

It can be run by calling:
```
python setup.py install
```

Anyone who adds new dependencies should be updating setup.py and adding the names of the packages found on pip in the install_requires list.